### PR TITLE
Update Docs (model: public/private) and simplify model images PUT API URL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ General Info
 
 * Models can be set as public/private. If public, the model and its associated
   results are available to all users. If private, it can only be seen by users who
-  have access to the *host Collab*.
+  have access to the *host Collab*. See table below for summary of access privileges.
 
 * No information can be deleted from the *Model Catalog* and *Validation Framework*
   apps. In future, an option to *hide* data would be implemented. This would offer
@@ -109,6 +109,61 @@ General Info
 
 * Models, model instances, tests and test instances can be edited as long as
   there are no results associated with them. Results can never be edited!
+
+  .. raw:: html
+
+    <div>
+    <style type="text/css">
+    .tg  {border-collapse:collapse;border-spacing:0;}
+    .tg td{font-family:Arial, sans-serif;font-size:14px;padding:11px 8px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:black;}
+    .tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:11px 8px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:black;}
+    .tg .tg-6v17{font-weight:bold;font-size:14px;background-color:#d6eebe;border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-ynlj{font-size:14px;background-color:#ffffff;border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-5jl3{font-style:italic;font-size:14px;background-color:#c3b696;border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-iu76{font-weight:bold;font-size:18px;background-color:#ffce93;border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-7xg9{font-weight:bold;font-style:italic;font-size:16px;background-color:#ffffc7;border-color:inherit;text-align:center;vertical-align:top}
+    .tg .tg-ecuv{font-weight:bold;font-size:18px;background-color:#ffce93;border-color:inherit;text-align:center}
+    </style>
+    <table class="tg">
+      <tr>
+        <th class="tg-c3ow" colspan="2" rowspan="3"></th>
+        <th class="tg-iu76" colspan="6">Collab (Private/Public)</th>
+      </tr>
+      <tr>
+        <td class="tg-7xg9" colspan="3">Collab Member</td>
+        <td class="tg-7xg9" colspan="3">Not Collab Member</td>
+      </tr>
+      <tr>
+        <td class="tg-5jl3">View (GET)</td>
+        <td class="tg-5jl3">Create (POST)</td>
+        <td class="tg-5jl3">Edit (PUT)</td>
+        <td class="tg-5jl3">View (GET)</td>
+        <td class="tg-5jl3">Create (POST)</td>
+        <td class="tg-5jl3">Edit (PUT)</td>
+      </tr>
+      <tr>
+        <td class="tg-ecuv" rowspan="2">Model</td>
+        <td class="tg-7xg9">Private</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-ynlj">No</td>
+        <td class="tg-ynlj">No</td>
+        <td class="tg-ynlj">No</td>
+      </tr>
+      <tr>
+        <td class="tg-7xg9">Public</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-6v17">Yes</td>
+        <td class="tg-ynlj">No</td>
+        <td class="tg-ynlj">No</td>
+      </tr>
+    </table>
+    </div>
+
 
 Regarding HBP Authentication
 ============================

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -2118,7 +2118,7 @@ class ModelCatalog(BaseClient):
         if image_id == "":
             raise Exception("Image ID needs to be provided for finding the image (figure).")
         else:
-            url = self.url + "/images/?id=" + image_id + "&format=json"
+            url = self.url + "/images/?format=json"
         headers = {'Content-type': 'application/json'}
         response = requests.put(url, data=json.dumps([image_data]), auth=self.auth, headers=headers)
         if response.status_code == 202:


### PR DESCRIPTION
Two updates:
1) Adds table describing access privileges for public/private models
2) Simplifies REST API URL for editing model images